### PR TITLE
feat: add cfdrop skills

### DIFF
--- a/skills/cfdrop-relay/SKILL.md
+++ b/skills/cfdrop-relay/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cfdrop-relay
+description: Push a freshly deployed cfdrop URL to a cfdrop relay so a paired viewer device (e.g. an iPad running the cfdrop viewer app) opens it automatically. Use when the user says "cfdrop and open on the viewer", "push to the relay", "show it on the iPad", or wants a deployed site to appear on a paired screen without sharing the URL manually.
+---
+
+# cfdrop-relay — Auto-open Deploys on a Paired Viewer
+
+Extends the `cfdrop` skill: after a successful deploy, `--notify` (cfdrop ≥0.6.0)
+pushes the live URL to a relay server, and any viewer device paired with that relay
+opens the site immediately. The relay server and viewer app live in the
+`cfdrop-app` repo.
+
+## Prerequisites
+
+- `cfdrop` ≥0.6.0 (`cfdrop --version`)
+- A running cfdrop relay (default port 8788) reachable from this machine — referred
+  to below as `relay-host`
+- The relay token, stored on the relay host at `~/.cfdrop-relay-token`
+
+## Usage
+
+```bash
+export CFDROP_NOTIFY=http://relay-host:8788   # relay endpoint
+export CFDROP_RELAY_TOKEN=$(ssh relay-host 'cat ~/.cfdrop-relay-token')
+
+cfdrop deploy --directory /tmp/<slug>-site --name <slug> -y --notify
+```
+
+Everything else (site generation, mobile design rules, verification) follows the
+base `cfdrop` skill — `--notify` is purely additive.
+
+## Behavior
+
+1. cfdrop deploys as usual and prints the live URL.
+2. It warms up the site first (probes `<url>/?cfdrop-warmup=N` with retries) so the
+   viewer doesn't land on a cold edge cache.
+3. It POSTs the URL to `CFDROP_NOTIFY` with the token in an `x-relay-token` header.
+4. On success it prints `Pushed URL to relay at <endpoint>.`
+
+## Failure modes
+
+- **Notify failure never fails the deploy** — the site is live either way; cfdrop
+  prints `warning: relay notify failed: ...` and exits 0. Re-share the URL manually.
+- `CFDROP_RELAY_TOKEN must be set for --notify` — export the token (see Usage).
+- `relay returned 401/403` — token mismatch; re-read it from
+  `relay-host:~/.cfdrop-relay-token`.
+- `warning: site not reachable yet, skipping notify` — warm-up probes never got a
+  200; the URL is still printed, push it again once the site responds (redeploying
+  with `--notify` is idempotent).
+- Connection refused — relay not running on `relay-host`, or wrong `CFDROP_NOTIFY`.

--- a/skills/cfdrop-relay/SKILL.md
+++ b/skills/cfdrop-relay/SKILL.md
@@ -5,14 +5,14 @@ description: Push a freshly deployed cfdrop URL to a cfdrop relay so a paired vi
 
 # cfdrop-relay — Auto-open Deploys on a Paired Viewer
 
-Extends the `cfdrop` skill: after a successful deploy, `--notify` (cfdrop ≥0.6.0)
+Extends the `cfdrop` skill: after a successful deploy, `--notify` (cfdrop ≥0.6.1)
 pushes the live URL to a relay server, and any viewer device paired with that relay
 opens the site immediately. The relay server and viewer app live in the
 `cfdrop-app` repo.
 
 ## Prerequisites
 
-- `cfdrop` ≥0.6.0 (`cfdrop --version`)
+- `cfdrop` ≥0.6.1 (`cfdrop --version`)
 - A running cfdrop relay (default port 8788) reachable from this machine — referred
   to below as `relay-host`
 - The relay token, stored on the relay host at `~/.cfdrop-relay-token`
@@ -34,13 +34,15 @@ base `cfdrop` skill — `--notify` is purely additive.
 1. cfdrop deploys as usual and prints the live URL.
 2. It warms up the site first (probes `<url>/?cfdrop-warmup=N` with retries) so the
    viewer doesn't land on a cold edge cache.
-3. It POSTs the URL to `CFDROP_NOTIFY` with the token in an `x-relay-token` header.
+3. It POSTs the URL to `${CFDROP_NOTIFY}/push` with the token in an
+   `x-relay-token` header.
 4. On success it prints `Pushed URL to relay at <endpoint>.`
 
 ## Failure modes
 
 - **Notify failure never fails the deploy** — the site is live either way; cfdrop
   prints `warning: relay notify failed: ...` and exits 0. Re-share the URL manually.
+- `CFDROP_NOTIFY must be set for --notify` — export the relay endpoint (see Usage).
 - `CFDROP_RELAY_TOKEN must be set for --notify` — export the token (see Usage).
 - `relay returned 401/403` — token mismatch; re-read it from
   `relay-host:~/.cfdrop-relay-token`.

--- a/skills/cfdrop/SKILL.md
+++ b/skills/cfdrop/SKILL.md
@@ -29,7 +29,9 @@ return a live `workers.dev` URL. Sites live ~60 minutes unless claimed.
    **HTML path (only for app-like UIs):** stat-tile dashboards, badge-heavy indexes
    with tappable cards, and copy-to-clipboard buttons need templated HTML. (Plain
    diagrams no longer justify HTML — use mermaid on the markdown path.) Inline the
-   CSS from `assets/base.css` (this skill dir) into each page's `<style>`. Structure:
+   CSS from `assets/base.css` (this skill dir) into each page's `<style>`. Every HTML
+   page must include `<meta name="viewport" content="width=device-width, initial-scale=1">`
+   in `<head>` so mobile breakpoints use the device width. Structure:
    - `index.html` — header, 2×2 stat tiles (grid), then one full-width tappable card
      per item linking to `/<id>`
    - `<id>.html` — one page per item: header card with "← All items" back link and an
@@ -60,31 +62,58 @@ return a live `workers.dev` URL. Sites live ~60 minutes unless claimed.
 - Dark theme tokens, badges, and all of the above are already in `assets/base.css` —
   don't rewrite it, inline it.
 - **Every `<textarea>` must have a working copy button.** Wrap each one in
-  `.textarea-copy`, place a `.copybtn` inside the wrapper, and copy the textarea's
-  current `.value` (not `innerText`). This applies to readonly output and editable
-  textareas so user edits are copied too. Use unique labels when multiple textareas
-  appear on one page, and include this delegated handler once per page:
+  `.textarea-copy`, place a `.copybtn` and an `aria-live` status inside the wrapper,
+  and copy the textarea's current `.value` (not `innerText`). This applies to readonly
+  output and editable textareas so user edits are copied too. Use unique accessible
+  labels when multiple textareas appear on one page, and include this delegated handler
+  once per page:
 
   ```html
   <div class="textarea-copy">
     <button type="button" class="copybtn" aria-label="Copy textarea contents">Copy</button>
+    <span class="copy-status" role="status" aria-live="polite"></span>
     <textarea>Text to copy</textarea>
   </div>
   <script>
   document.addEventListener('click', async (event) => {
     const button = event.target.closest('.textarea-copy .copybtn');
-    if (!button) return;
-    const textarea = button.closest('.textarea-copy').querySelector('textarea');
-    const label = button.textContent;
+    if (!button || button.dataset.copying === 'true') return;
+
+    const wrapper = button.closest('.textarea-copy');
+    const textarea = wrapper.querySelector('textarea');
+    const status = wrapper.querySelector('.copy-status');
+    const label = button.dataset.copyLabel || button.textContent;
+    const ariaLabel = button.dataset.copyAriaLabel ||
+      button.getAttribute('aria-label') || label;
+    button.dataset.copyLabel = label;
+    button.dataset.copyAriaLabel = ariaLabel;
+    button.dataset.copying = 'true';
+
+    let copied = false;
     try {
       await navigator.clipboard.writeText(textarea.value);
+      copied = true;
     } catch {
-      textarea.focus();
-      textarea.select();
-      document.execCommand('copy');
+      try {
+        textarea.focus();
+        textarea.select();
+        copied = document.execCommand('copy');
+      } catch {
+        copied = false;
+      }
     }
-    button.textContent = '✓ Copied';
-    setTimeout(() => { button.textContent = label; }, 1500);
+
+    const message = copied ? 'Copied to clipboard' : 'Copy failed';
+    button.textContent = copied ? '✓ Copied' : 'Copy failed';
+    button.setAttribute('aria-label', message);
+    if (status) status.textContent = message;
+    delete button.dataset.copying;
+    clearTimeout(button._copyReset);
+    button._copyReset = setTimeout(() => {
+      button.textContent = label;
+      button.setAttribute('aria-label', ariaLabel);
+      if (status) status.textContent = '';
+    }, 1500);
   });
   </script>
   ```

--- a/skills/cfdrop/SKILL.md
+++ b/skills/cfdrop/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: cfdrop
+description: Explain or present anything as a mobile-optimized static website deployed to a temporary Cloudflare account via the cfdrop CLI. Use when the user says "cfdrop this", "explain this by cfdrop", "cfdrop mobile optimized", "deploy as mobile site", or asks to turn content (a topic, codebase, issue list, analysis, report) into a browsable mobile web page with a live URL.
+---
+
+# cfdrop — Explain Anything as a Mobile Site
+
+Generate mobile-first static web assets that explain the requested subject, deploy them
+with the `cfdrop` CLI (self-contained Rust binary, no Cloudflare account needed), and
+return a live `workers.dev` URL. Sites live ~60 minutes unless claimed.
+
+## Workflow
+
+1. **Understand the subject.** "Explain this" may point at code, issues, a document, a
+   conversation topic. Gather what's needed (read files, fetch issues, run analysis).
+   For many independent items needing deep analysis, fan out to subagents that each
+   write `/tmp/<slug>-analysis/<id>.json`.
+2. **Generate the site** into `/tmp/<slug>-site/` (slug = short kebab-case subject name).
+
+   **Markdown path (prefer for prose-heavy subjects):** write `*.md` files into the
+   directory and deploy with `--md` — cfdrop (≥0.2.0) converts them to mobile-first
+   dark-theme pages itself (tables, code blocks, blockquotes handled; auto index of
+   tappable cards unless you provide `index.md`). Use real backticks for identifiers,
+   and language-tagged fences (```rust, ```bash, ...) — cfdrop ≥0.3.0 syntax-highlights
+   them at build time (no client JS). ```mermaid fences render as diagrams (cfdrop
+   ≥0.4.0 bundles mermaid.js into the site — no CDN); prefer `graph TD` (top-down)
+   for mobile. This needs no HTML generation at all.
+
+   **HTML path (only for app-like UIs):** stat-tile dashboards, badge-heavy indexes
+   with tappable cards, and copy-to-clipboard buttons need templated HTML. (Plain
+   diagrams no longer justify HTML — use mermaid on the markdown path.) Inline the
+   CSS from `assets/base.css` (this skill dir) into each page's `<style>`. Structure:
+   - `index.html` — header, 2×2 stat tiles (grid), then one full-width tappable card
+     per item linking to `/<id>`
+   - `<id>.html` — one page per item: header card with "← All items" back link and an
+     outbound source link, then numbered sections (summary / current-vs-expected flow
+     diagram / analysis / suggested action — adapt sections to the subject)
+3. **Deploy:** `cfdrop deploy --directory /tmp/<slug>-site --name <slug> -y`
+   - Add `--auth user:pass` if the user wants the site gated (HTTP Basic Auth)
+   - `-y` is required non-interactively (accepts Cloudflare ToS)
+4. **Verify:** curl the index and one detail page, expect 200. An immediate curl can hit
+   a stale edge cache — append `?v=N` or retry once before concluding failure.
+5. **Report:** live URL, expiry (~60 min), and the claim URL (printed by cfdrop) so the
+   user can keep the account. The claim URL is a bearer credential — show it to the
+   user, never publish it on the site itself.
+
+## Mobile design rules (non-negotiable)
+
+- **Vertical scrolling only.** `html,body { overflow-x:hidden }`, `* { min-width:0 }`,
+  `overflow-wrap:anywhere` on titles/paths/URLs. Never use wide tables — use stacked
+  block cards instead.
+- **Block/tile composition.** Stats as a CSS grid (2 columns ≤480px), one card per item,
+  full width, generous tap targets (whole card is the `<a>`).
+- **Diagrams**: on the markdown path use ```mermaid fences — `graph TD` (top-down) for
+  flows, `sequenceDiagram` for interactions; keep node labels short so they fit a phone.
+  Current-vs-expected = two small `graph TD` blocks under `## Current` / `## Expected`
+  headings. On the HTML path, flow diagrams are stacked boxes joined by `↓` arrows
+  (two columns via `grid-template-columns:1fr 1fr`, collapsing to `1fr` ≤560px), each
+  step under ~12 words.
+- Dark theme tokens, badges, and all of the above are already in `assets/base.css` —
+  don't rewrite it, inline it.
+- **Every `<textarea>` must have a working copy button.** Wrap each one in
+  `.textarea-copy`, place a `.copybtn` inside the wrapper, and copy the textarea's
+  current `.value` (not `innerText`). This applies to readonly output and editable
+  textareas so user edits are copied too. Use unique labels when multiple textareas
+  appear on one page, and include this delegated handler once per page:
+
+  ```html
+  <div class="textarea-copy">
+    <button type="button" class="copybtn" aria-label="Copy textarea contents">Copy</button>
+    <textarea>Text to copy</textarea>
+  </div>
+  <script>
+  document.addEventListener('click', async (event) => {
+    const button = event.target.closest('.textarea-copy .copybtn');
+    if (!button) return;
+    const textarea = button.closest('.textarea-copy').querySelector('textarea');
+    const label = button.textContent;
+    try {
+      await navigator.clipboard.writeText(textarea.value);
+    } catch {
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+    }
+    button.textContent = '✓ Copied';
+    setTimeout(() => { button.textContent = label; }, 1500);
+  });
+  </script>
+  ```
+- **Code identifiers**: markdown path — just use real backticks (and language-tagged
+  fences); cfdrop renders and highlights them. HTML path — wrap identifiers in `<code>`
+  tags (see the `codify()` regex pass in `examples/gen-triage-site.py` in this repo);
+  styling is in `assets/base.css` (`.prose code`).
+- Link detail pages **without** the `.html` extension (`href="/123"`) — cfdrop deploys
+  with `html_handling: auto-trailing-slash`, which serves them.
+
+## cfdrop CLI facts
+
+- Binary: `cfdrop` on PATH (release binaries for linux-amd64/arm64 + macos-arm64 on
+  this repo's GitHub releases). Feature floor: `--md` needs ≥0.2.0, syntax
+  highlighting ≥0.3.0, mermaid ≥0.4.0 — check `cfdrop --version` if a feature seems
+  missing.
+- `cfdrop status` — cached temp account, expiry, claim URL; `cfdrop logout` — forget it;
+  `--fresh` — force a new account
+- The temp account is cached in the OS config dir (e.g.
+  `~/Library/Application Support/cfdrop/state.json` on macOS) and reused across deploys
+  until expiry — redeploys to the same `--name` update the same URL; different
+  `--name`s create sibling sites on one account with a shared clock
+- Limits: ≤1,000 files, ≤5 MiB/file; hidden files skipped
+- `--auth` bakes the credential into the Worker script — preview-grade only; for
+  long-lived sites the user should claim the account and use Cloudflare Access
+- If the account expired, deploy just provisions a new one (~1s proof-of-work); old
+  URLs die with the old account — re-share the new URL
+
+## Content quality bar
+
+- Index answers "what is this and how much of it" at a glance (counts, type badges,
+  age); detail pages answer "what, why, what next" in numbered sections
+- For issue/bug subjects: summary in plain language, current-vs-expected flow (mermaid
+  on the markdown path, box columns on the HTML path), root cause citing real file
+  paths, and a suggested response (HTML path: add a copy button via
+  `navigator.clipboard.writeText`)
+- Mark AI-generated analysis in the footer: "AI-assisted analysis — verify before posting"

--- a/skills/cfdrop/assets/base.css
+++ b/skills/cfdrop/assets/base.css
@@ -68,12 +68,14 @@ h2 { font-size:.8rem; text-transform:uppercase; letter-spacing:.06em; color:var(
 
 /* copy-to-clipboard blocks */
 .resp, .textarea-copy { position:relative; }
-.copybtn { position:absolute; top:8px; right:8px; z-index:1; min-height:36px; background:var(--line);
-           color:var(--fg); border:1px solid #3a3f50; border-radius:7px; padding:6px 12px;
-           font:600 .75rem/1 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+.copybtn { position:absolute; top:8px; right:8px; z-index:1; min-height:44px; background:var(--line);
+           color:var(--fg); border:1px solid #3a3f50; border-radius:7px; padding:8px 12px;
+           font:600 .875rem/1 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
            cursor:pointer; touch-action:manipulation; }
 .copybtn:focus-visible { outline:2px solid var(--blue); outline-offset:2px; }
+.copy-status { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden;
+           clip:rect(0,0,0,0); white-space:nowrap; border:0; }
 .textarea-copy textarea { display:block; width:100%; min-height:9rem; resize:vertical; background:var(--card);
-           color:var(--fg); border:1px solid var(--line); border-radius:12px; padding:54px 14px 14px;
-           font:.85rem/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; overflow-wrap:anywhere; }
+           color:var(--fg); border:1px solid var(--line); border-radius:12px; padding:62px 14px 14px;
+           font:1rem/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; overflow-wrap:anywhere; }
 .textarea-copy textarea:focus { border-color:var(--blue); outline:1px solid var(--blue); }

--- a/skills/cfdrop/assets/base.css
+++ b/skills/cfdrop/assets/base.css
@@ -1,0 +1,79 @@
+/* cfdrop mobile-first design system — inline into <style> of every generated page.
+   Verified on live deploys: no horizontal scroll, tile/card layout, dark theme. */
+
+:root { --bg:#0f1117; --card:#1a1d26; --fg:#e6e8ee; --dim:#8b90a0; --line:#2a2e3b;
+        --orange:#ff9900; --red:#f2555a; --green:#4cc38a; --blue:#6ca0f5; }
+* { box-sizing:border-box; margin:0; min-width:0; }
+html, body { overflow-x:hidden; }
+body { background:var(--bg); color:var(--fg); font:16px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+       padding:16px; max-width:720px; margin:0 auto; -webkit-text-size-adjust:100%; }
+a { color:var(--blue); }
+h1 { font-size:1.2rem; margin-bottom:4px; overflow-wrap:anywhere; }
+h1 .repo { color:var(--orange); }
+.sub { color:var(--dim); font-size:.85rem; margin-bottom:16px; overflow-wrap:anywhere; }
+
+/* badges */
+.b { padding:1px 8px; border-radius:99px; font-size:.72rem; font-weight:600; white-space:nowrap; }
+.b-bug { background:#3a1d20; color:var(--red); }
+.b-feat { background:#16301f; color:var(--green); }
+.b-other { background:#2a2e3b; color:var(--dim); }
+.b-warn { background:#33261a; color:var(--orange); }
+.mod { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; color:var(--blue); overflow-wrap:anywhere; }
+footer { color:var(--dim); font-size:.75rem; text-align:center; margin:24px 0 8px; overflow-wrap:anywhere; }
+
+/* index: stat tiles */
+.stats { display:grid; grid-template-columns:repeat(4,1fr); gap:8px; margin-bottom:20px; }
+@media (max-width:480px) { .stats { grid-template-columns:repeat(2,1fr); } }
+.stat { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:12px; text-align:center; }
+.stat .v { font-size:1.5rem; font-weight:700; }
+.stat .k { font-size:.75rem; color:var(--dim); text-transform:uppercase; letter-spacing:.04em; }
+.v.red { color:var(--red); } .v.green { color:var(--green); } .v.blue { color:var(--blue); }
+
+/* index: item cards (whole card is the link) */
+.card { display:block; width:100%; background:var(--card); border:1px solid var(--line); border-radius:12px;
+        padding:12px 14px; margin-bottom:10px; text-decoration:none; color:var(--fg); }
+.card:active { background:#232734; }
+.row1 { display:flex; flex-wrap:wrap; align-items:center; gap:6px 8px; font-size:.8rem; margin-bottom:6px; }
+.num { color:var(--dim); font-variant-numeric:tabular-nums; }
+.meta { margin-left:auto; color:var(--dim); }
+.title { font-size:.95rem; font-weight:600; margin-bottom:6px; overflow-wrap:anywhere; }
+.row2 { display:flex; flex-wrap:wrap; gap:4px 10px; font-size:.78rem; color:var(--dim); }
+.author { overflow-wrap:anywhere; }
+
+/* detail pages */
+.back { display:inline-block; margin-bottom:12px; font-size:.85rem; text-decoration:none; }
+.hdr { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:14px; margin-bottom:16px; }
+.hdr .row1 { display:flex; flex-wrap:wrap; align-items:center; gap:6px 8px; font-size:.8rem; margin-bottom:8px; }
+.hdr .title { font-size:1.05rem; font-weight:700; margin-bottom:8px; }
+.ghlink { font-size:.85rem; }
+section { margin-bottom:20px; }
+h2 { font-size:.8rem; text-transform:uppercase; letter-spacing:.06em; color:var(--dim); margin-bottom:10px;
+     border-bottom:1px solid var(--line); padding-bottom:6px; }
+.prose { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:14px;
+         font-size:.92rem; overflow-wrap:anywhere; white-space:pre-wrap; }
+.prose code, .step code { background:#232734; border:1px solid var(--line); border-radius:5px;
+       padding:0 4px; font:.85em ui-monospace,SFMono-Regular,Menlo,monospace;
+       color:var(--blue); overflow-wrap:anywhere; }
+
+/* vertical flow diagram: current (red) vs expected (green) */
+.flowwrap { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
+@media (max-width:560px) { .flowwrap { grid-template-columns:1fr; } }
+.flow { background:var(--card); border:1px solid var(--line); border-radius:12px; padding:12px; }
+.flow h3 { font-size:.78rem; text-transform:uppercase; letter-spacing:.05em; text-align:center; margin-bottom:10px; }
+.flow.cur h3 { color:var(--red); } .flow.exp h3 { color:var(--green); }
+.step { border-radius:8px; padding:8px 10px; font-size:.82rem; text-align:center; overflow-wrap:anywhere; }
+.flow.cur .step { background:#2a1a1c; border:1px solid #4a2a2e; }
+.flow.exp .step { background:#14251c; border:1px solid #23483a; }
+.arrow { text-align:center; color:var(--dim); font-size:.9rem; line-height:1.6; }
+
+/* copy-to-clipboard blocks */
+.resp, .textarea-copy { position:relative; }
+.copybtn { position:absolute; top:8px; right:8px; z-index:1; min-height:36px; background:var(--line);
+           color:var(--fg); border:1px solid #3a3f50; border-radius:7px; padding:6px 12px;
+           font:600 .75rem/1 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+           cursor:pointer; touch-action:manipulation; }
+.copybtn:focus-visible { outline:2px solid var(--blue); outline-offset:2px; }
+.textarea-copy textarea { display:block; width:100%; min-height:9rem; resize:vertical; background:var(--card);
+           color:var(--fg); border:1px solid var(--line); border-radius:12px; padding:54px 14px 14px;
+           font:.85rem/1.5 ui-monospace,SFMono-Regular,Menlo,monospace; overflow-wrap:anywhere; }
+.textarea-copy textarea:focus { border-color:var(--blue); outline:1px solid var(--blue); }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,9 @@ enum Command {
         /// HTML pages (auto-generated index unless index.md exists)
         #[arg(long)]
         md: bool,
-        /// After a successful deploy, push the URL to a cfdrop relay so the
-        /// iPad viewer opens it. Endpoint from CFDROP_NOTIFY (default
-        /// http://192.168.0.176:8788), token from CFDROP_RELAY_TOKEN.
+        /// After a successful deploy, push the URL to a cfdrop relay so a
+        /// paired viewer opens it. Endpoint from CFDROP_NOTIFY, token from
+        /// CFDROP_RELAY_TOKEN.
         #[arg(long)]
         notify: bool,
     },
@@ -270,7 +270,7 @@ fn wait_until_live(url: &str, max: std::time::Duration) -> Result<std::time::Dur
 /// Never fatal: the deploy already succeeded.
 fn notify_relay(url: &str) -> Result<String> {
     let endpoint = std::env::var("CFDROP_NOTIFY")
-        .unwrap_or_else(|_| "http://192.168.0.176:8788".to_string());
+        .context("CFDROP_NOTIFY must be set for --notify")?;
     let token = std::env::var("CFDROP_RELAY_TOKEN")
         .context("CFDROP_RELAY_TOKEN must be set for --notify")?;
     let resp = reqwest::blocking::Client::builder()


### PR DESCRIPTION
## Summary
- add a basic `cfdrop` skill for generating mobile-first sites and returning temporary Cloudflare URLs
- bundle the reusable mobile design CSS and require copy buttons for every textarea
- add a separate `cfdrop-relay` skill using generic `relay-host` configuration

## Validation
- both skills pass `skill-creator/scripts/quick_validate.py`
- all new files pass whitespace checks
- verified relay-specific settings appear only in `cfdrop-relay`
- independently reviewed against the CLI implementation